### PR TITLE
Successful render

### DIFF
--- a/components/Paths.vue
+++ b/components/Paths.vue
@@ -1,7 +1,7 @@
 <template>
   <path 
     :class="{active: isActive}"
-    v-on:dblclick="toggleChildren(items.children)"
+    v-on:dblclick="toggleChildren(items.children, branchName)"
 
     :id="branchName"
     :d="dString(items)" 
@@ -19,23 +19,10 @@ import { DisplayMixin } from "~/components/DisplayMixin.js";
 export default {
   props: ['items', 'branchName'],
   mixins: [PathsMixin, DisplayMixin],
-  data() {
-    return {
-      isActive: undefined, 
-    }
-  },
-  created (children=this.items.children) {
-    const childLen = children.length
-    if (childLen) {
-      const xBoolArr = children.map(child => this._$[child].x.length===1)
-      const xSum = xBoolArr.reduce((a, b) => a + b, 0)
-      if (xSum>0 && xSum>=childLen){
-        // Root branch is child & none root children hiden
-        this.isActive = false // can be toggled to reveal the rest
-        // Root children is bad form and should be avoided though.
-      } else {
-        this.isActive = true
-      }
+  computed: {
+    isActive() {
+      var displayed = this.$store.state.show
+      return !this.items.children.every((val) => displayed.includes(val))
     }
   },
   methods: {
@@ -62,6 +49,9 @@ export default {
         }
       }
     },
+
+
+
     dXUpdate(parentX, childKey, mod=1){ // +/- modifier
       const childX = this._$[childKey].x
       const dx = mod * this.$store.getters.maxDx(childKey)
@@ -99,22 +89,28 @@ export default {
         }
       }
     },
-    toggleChildren(children) {
-      // This will change when implementing official vuex mutations
+    toggleChildren(children, branchName) {
       if (children.length) {
-        this.isActive = !this.isActive
-        if (this.isActive === false) {
+        if (this.isActive === true) {
           // assuming all children are spaced appropriately i should 
           // only have to do the 2 most extreme child +/- children
-          for (var key of children){  
-            var x = this._$[key].x
+          for (var key of children){ 
             this.dXUpdate(this.items.x, key, +1) //add dx value
           }
           this.$store.commit('addVisible', children)
         } else {
           for (var key of children){
-            this.dXUpdate(this.items.x, key, -1) //subtract dx value
-            this.$store.commit('removeVisible', key) //need to recursively remove for sub children...
+            var subChild = this._$[key].children
+            var show = this.$store.state.show
+            var activeChildren = subChild.filter(branch => show.includes(branch))
+            // Recusrion for children with descendants
+            if (activeChildren.length>0){
+              this.toggleChildren(activeChildren, key)
+            }
+            // Update current parent dx/show
+            this.dXUpdate(this._$[branchName].x, key, -1) //-1 subtract dx value
+            this.$store.commit('removeVisible', key)
+            
           }
         }
         console.log("state.show: ", this.$store.state.show)

--- a/store/index.js
+++ b/store/index.js
@@ -363,7 +363,10 @@ export const mutations = {
     state.show = [... new Set(updated)]  // remove duplicates
   },
   removeVisible (state, key) {
-    state.show.splice(state.show.indexOf(key), 1)
+    var index = state.show.indexOf(key) // -1 if none
+    if (index>-1) {
+      state.show.splice(index, 1)
+    }
   },
   dx (state, payload) {
     state.branches[payload.key].dx += payload.value


### PR DESCRIPTION
store/index.js:
Update prevents unfound keys from poping the last element of the list.

Paths.vue:
'isActive' now a computed value, thus toggle does not influence it. Far more succinct.

toggleChildren()
• minor cleanup and bool change due to 'isActive' update
• branchName parameter needed for recursion to pass current parents X list.
• Children actively showing decendants added to 'activeChildren'.
• 'activeChildren' passed recursively untill terminal branch reached. Current parents will then be updated back toward the origional collapse.
• recusion compatible dXUpdate