### PR TITLE
Extend/Replace D-string items

### DIFF
--- a/components/Paths/PathsMixin.js
+++ b/components/Paths/PathsMixin.js
@@ -1,6 +1,7 @@
 export const PathsMixin = {
   methods: {
     ExtendOrReplace(d, x, y, marker, string) {
+      // If repeat, overwrite. Otherwise, extened dString.
       let last_index = d.length-1
       if (d.length>0 && d[last_index][0] === marker) {
         d[last_index] = (string) // Overwrite repeat


### PR DESCRIPTION
Generalized function created to support SVG path calculations.
Back to back lines and move-to's are condensed to a single item.

Minor cleanup under branch as well.